### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=12 <17"
   },
   "build": {
     "productName": "OPF Carrus",
@@ -69,8 +69,8 @@
     "veraPDF-unzip:linux": "cd ./libs && unzip verapdf-installer.zip && rm -rf verapdf-installer.zip",
     "veraPDF-unzip:mac": "cd ./libs && unzip verapdf-installer.zip",
     "veraPDF": "cd ./libs/veraPDF && java -DINSTALL_PATH=%cd%/libs/veraPDF -jar verapdf-greenfield-1.18.6/verapdf-izpack-installer-1.18.6.jar -options-system && rd /s /q verapdf-greenfield-1.18.6",
-    "veraPDF:linux": "cd ./libs && java -DINSTALL_PATH=$(pwd)/veraPDF -jar verapdf-greenfield-1.16.1/verapdf-izpack-installer-1.16.1.jar -options-system && rm -rf verapdf-greenfield-1.16.1",
-    "veraPDF:mac": "cd ./libs && java -DINSTALL_PATH=$(pwd)/veraPDF -jar verapdf-greenfield-1.16.1/verapdf-izpack-installer-1.16.1.jar -options-system && rm -rf verapdf-greenfield-1.16.1",
+    "veraPDF:linux": "cd ./libs && java -DINSTALL_PATH=$(pwd)/veraPDF -jar verapdf-greenfield-1.18.6/verapdf-izpack-installer-1.18.6.jar -options-system && rm -rf verapdf-greenfield-1.18.6",
+    "veraPDF:mac": "cd ./libs && java -DINSTALL_PATH=$(pwd)/veraPDF -jar verapdf-greenfield-1.18.6/verapdf-izpack-installer-1.18.6.jar -options-system && rm -rf verapdf-greenfield-1.18.6",
     "jpylyzer": "git clone https://github.com/openpreserve/jpylyzer.git ./libs/jpylyzer && cd ./libs/jpylyzer && rm -rf .git"
   },
   "dependencies": {


### PR DESCRIPTION
When trying to compile the app on Node v17 I was getting errors error:0308010C:digital envelope routines::unsupported reading online showed this was related to openssl. The hacks and workarounds seem to disable security. But an easier option was to use Node v16 - so I have added a constraint to the node engine in the package.json"
[master e732cfa] When trying to compile the app on Node v17 I was getting errors error:0308010C:digital envelope routines::unsupported reading online showed this was related to openssl. The hacks and workarounds seem to disable security. But an easier option was to use Node v16 - so I have added a constraint to the node engine in the package.json

I also noticed that veraPDF version numbers didn't match, so made them match the current version that gets downloaded bu the download script